### PR TITLE
Remove simple_form deprecation warnings

### DIFF
--- a/lib/rails4-autocomplete/simple_form_plugin.rb
+++ b/lib/rails4-autocomplete/simple_form_plugin.rb
@@ -16,7 +16,7 @@ module SimpleForm
     class AutocompleteInput < Base
       include Autocomplete
 
-      def input
+      def input(wrapper_options)
         @builder.autocomplete_field(
           attribute_name,
           options[:url],
@@ -37,7 +37,7 @@ module SimpleForm
     class AutocompleteCollectionInput < CollectionInput
       include Autocomplete
 
-      def input
+      def input(wrapper_options)
         # http://www.codeofficer.com/blog/entry/form_builders_in_rails_discovering_field_names_and_ids_for_javascript/
         hidden_id = "#{object_name}_#{attribute_name}_hidden".gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_").sub(/_$/, "")
         id_element = options[:id_element]


### PR DESCRIPTION
P.S.: Noticed I still need to fix the tests. Please, don't do anything yet.

Hi,

Just fixed a simple_form deprecation warning. See https://github.com/plataformatec/simple_form/pull/997. 

I know you are out of time, but that might be quick to merge in :) I made it because I'm using this gem in a project, and simple_form is spitting deprecation warnings on my controller tests.