### PR TITLE
search capability in any table of a join

### DIFF
--- a/lib/rails4-autocomplete/orm/active_record.rb
+++ b/lib/rails4-autocomplete/orm/active_record.rb
@@ -4,12 +4,13 @@ module Rails4Autocomplete
       def get_autocomplete_order(method, options, model=nil)
         order = options[:order]
 
-        table_prefix = model ? "#{model.table_name}." : ""
+        table_prefix = model ? "#{ options[:table_name] ||= model.table_name}." : ""
         order || "#{table_prefix}#{method} ASC"
       end
 
       def get_autocomplete_items(parameters)
         model   = parameters[:model]
+        table_name = parameters[:table_name]
         term    = parameters[:term]
         method  = parameters[:method]
         options = parameters[:options]
@@ -32,14 +33,14 @@ module Rails4Autocomplete
 
       def get_autocomplete_select_clause(model, method, options)
         table_name = model.table_name
-        (["#{table_name}.#{model.primary_key}", "#{table_name}.#{method}"] + (options[:extra_data].blank? ? [] : options[:extra_data]))
+        (["#{table_name}.#{model.primary_key}", "#{options[:table_name]}.#{method}"] + (options[:extra_data].blank? ? [] : options[:extra_data]))
       end
 
       def get_autocomplete_where_clause(model, term, method, options)
         table_name = model.table_name
         is_full_search = options[:full]
         like_clause = (postgres?(model) ? 'ILIKE' : 'LIKE')
-        ["LOWER(#{table_name}.#{method}) #{like_clause} ?", "#{(is_full_search ? '%' : '')}#{term.downcase}%"]
+        ["LOWER(#{options[:table_name]}.#{method}) #{like_clause} ?", "#{(is_full_search ? '%' : '')}#{term.downcase}%"]
       end
 
       def postgres?(model)


### PR DESCRIPTION
adding the option: table_name offers support for searching fields between tables when scopes are used.

for example:. without this option, the following join would look like, and it would not be possible to access a column from another table, unless the table used as a basis to join

# On the controller
autocomplete: item: produto_nome, scopes: [: join_produto_preco_produto] column_name, 'name'

SELECT itens.id, produtos.nome FROM INNER JOIN `` itens` produto_precos` ON ​​= `` produto_precos`.`id` itens`.`produto_preco_id` INNER JOIN products ON produto_precos.produto_id = produtos.id WHERE (LOWER (items. name) LIKE '% Wing') ORDER BY produtos.nome ASC LIMIT 10

... With the modification it is possible to specify the table to which the field belongs

# On the controller
autocomplete: item: produto_nome, scopes: [: join_produto_preco_produto] table_name, 'products', column_name, 'name'

SELECT itens.id, produtos.nome FROM INNER JOIN `` itens` produto_precos` ON ​​= `` produto_precos`.`id` itens`.`produto_preco_id` INNER JOIN products ON produto_precos.produto_id = produtos.id WHERE (LOWER (products. name) LIKE '% Wing') ORDER BY produtos.nome ASC LIMIT 10