### PR TITLE
Rails 4.1 bug fix.

### DIFF
--- a/lib/rails4-autocomplete/orm/active_record.rb
+++ b/lib/rails4-autocomplete/orm/active_record.rb
@@ -27,7 +27,7 @@ module Rails4Autocomplete
             limit(limit).order(order)
         items = items.where(where) unless where.blank?
 
-        items
+        items.to_a
       end
 
       def get_autocomplete_select_clause(model, method, options)


### PR DESCRIPTION
Fixes bug that affects Rails 4.1 and greater.

Results need to be converted to an array via `to_a` due to
this change in Rails 4.1:

“Relation no longer has mutator methods like #map! and #delete_if.
Convert to an Array by calling #to_a before using these methods.”
(http://edgeguides.rubyonrails.org/4_1_release_notes.html#active-record-
notable-changes)