### PR TITLE
minor change in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This options receives a method name as the parameter, and that method will be ca
 
     class Brand < ActiveRecord::Base
       def funky_method
-        "#{self.name}.camelize"
+        "#{self.name}".camelize
       end
     end
 


### PR DESCRIPTION
camelize method inside double-quotes adds "brand_name.camelize" instead of chaining the method